### PR TITLE
Extra jvectormap-tip div is destroyed on update

### DIFF
--- a/src/lib/components/VectorMap.js
+++ b/src/lib/components/VectorMap.js
@@ -53,6 +53,11 @@ class VectorMap extends React.PureComponent {
         this.$node.vectorMap({ ...this.props });
         this.$mapObject = this.$node.vectorMap("get", "mapObject");
         }
+        let jvectormapTips = document.getElementsByClassName('jvectormap-tip');
+        if (jvectormapTips.length > 1){
+            let extraTip = jvectormapTips[0];
+            extraTip.parentNode.removeChild(extraTip);
+        }
     }
 
     /**


### PR DESCRIPTION
Whenever new map jvectormap is created, it creates '<div` class="jvectormap-tip"></div>' which is used to create messages when people hover over specific regions of the map. Whenever componentDidUpdate is called, it creates a new map but does not destroy 'jvectormap-tip' and therefore, there are many jvectormap-tip after many updates. This request has an implementation that will destroy extra div elements that are created