### PR TITLE
Proposed bug fix for issue #10 & #21

### DIFF
--- a/packages/jvectormap/src/abstract-element.js
+++ b/packages/jvectormap/src/abstract-element.js
@@ -65,7 +65,9 @@ jvm.AbstractElement.prototype.get = function(property){
  * @private
  */
 jvm.AbstractElement.prototype.applyAttr = function(property, value){
-  this.node.setAttribute(property, value);
+  if (!Number.isNaN(value)) {
+    this.node.setAttribute(property, value);
+  }
 };
 
 jvm.AbstractElement.prototype.remove = function(){


### PR DESCRIPTION
# Regarding issue #10  & #21 
I also experienced the same error when resizing the window and I think I found a possible solution.

## Problem
The error come from the "applyAttr" method in the abstract-element.js file. Sometimes, when resizing the window, the "value" parameter receives NaN, which then throws an error.

## Solution

I added an if block that wraps "this.node.setAttribute" method invocation and checks if the 'value' argument is not NaN.
This way "setAttribute" receives the proper argument type. I have tested this implementation and it works on my local machine, but I don't know if this will conflict with anything else in the code base.

I hope this is helpful.