### PR TITLE
Array of strings should also be allowed for Scale

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -349,7 +349,7 @@ export interface ISeries {
   markers?: IAttributeSeries[];
 }
 
-type Scale = { [key: string]: string } | number[];
+type Scale = { [key: string]: string } | number[] | string[];
 
 type Values = { [key: string]: string | number };
 


### PR DESCRIPTION
I define the scale with an array of hexadecimal strings, not numbers.
This example for a scale would work well but
Throws a ts error:j
`scale: ['#C8EEFF', '#0071A4’]`
