### PR TITLE
Add zoomButtons to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ export interface IVectorMapProps extends IMapComponent {
    */
   backgroundColor?: string;
   /**
+   * Indicates whether zoom buttons are visible on map. Default value is true.
+   */
+  zoomButtons?: boolean;
+  /**
    * Indicates the minimum zoom ratio which could be reached zooming the map. Default value is 1.
    */
   zoomMin?: number;


### PR DESCRIPTION
There is a property `zoomButtons` in [map.js](https://github.com/kadoshms/react-jvectormap/blob/0bc48cb4435d06bd22d493b9df1238b220e25c0c/packages/jvectormap/src/map.js#L1231) which allows the zoom in and out buttons on the top left corner of the map to be hidden if required. The default value is true. We can use this property if we do not wish to show zoom buttons, for example, in scenarios where we do not wish to allow zooming of the map, or we wish to do it programmatically and not allow users to zoom.

This property was not documented in the README file before. I added this property to it. Please review and let me know if any changes need to be made.